### PR TITLE
feat: custom features support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,16 @@ For performance and robustness, we recommend using [install-action] if the tool 
 
 ### Inputs
 
-| Name   | Required | Description                                                                | Type    | Default |
-| ------ |:--------:| -------------------------------------------------------------------------- | ------- | ------- |
-| tool   | **✓**    | Crate to install                                                           | String  |         |
-| locked |          | Use `--locked` flag                                                        | Boolean | true    |
-| git    |          | Install from the specified Git URL (see [action.yml](action.yml) for more) | String  |         |
-| tag    |          | Tag to use when installing from git                                        | String  |         |
-| rev    |          | Specific commit to use when installing from git                            | String  |         |
+| Name                | Required | Description                                                                | Type    | Default |
+|---------------------|:--------:|----------------------------------------------------------------------------|---------|---------|
+| tool                | **✓**    | Crate to install                                                           | String  |         |
+| locked              |          | Use `--locked` flag                                                        | Boolean | true    |
+| git                 |          | Install from the specified Git URL (see [action.yml](action.yml) for more) | String  |         |
+| tag                 |          | Tag to use when installing from git                                        | String  |         |
+| rev                 |          | Specific commit to use when installing from git                            | String  |         |
+| features            |          | Comma-separated list of features to enable when installing the crate       | String  |         |
+| no-default-features |          | Pass `--no-default-features` to `cargo install`                            | Boolean | false   |
+| all-features        |          | Pass `--all-features` to `cargo install`                                   | Boolean | false   |
 
 ### Example workflow
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,18 @@ inputs:
   rev:
     description: Specific commit to use when installing from git
     required: false
+  features:
+    description: Comma-separated list of features to enable when installing the crate
+    required: false
+    default: ''
+  no-default-features:
+    description: Pass `--no-default-features` to `cargo install`
+    required: false
+    default: 'false'
+  all-features:
+    description: Pass `--all-features` to `cargo install`
+    required: false
+    default: 'false'
 
 # Note:
 # - inputs.* should be manually mapped to INPUT_* due to https://github.com/actions/runner/issues/665
@@ -59,6 +71,9 @@ runs:
         INPUT_GIT: ${{ inputs.git }}
         INPUT_TAG: ${{ inputs.tag }}
         INPUT_REV: ${{ inputs.rev }}
+        INPUT_FEATURES: ${{ inputs.features }}
+        INPUT_NO_DEFAULT_FEATURES: ${{ inputs.no-default-features }}
+        INPUT_ALL_FEATURES: ${{ inputs.all-features }}
     - name: Restore Cache
       id: cache
       uses: actions/cache@v4
@@ -69,7 +84,7 @@ runs:
       run: |
         export CARGO_NET_RETRY=10
         # shellcheck disable=SC2206
-        args=(-f "${{ steps.pre.outputs.tool }}" --root "${RUNNER_TOOL_CACHE}/${{ steps.pre.outputs.tool }}" ${{ steps.pre.outputs.locked }})
+        args=(-f "${{ steps.pre.outputs.tool }}" --root "${RUNNER_TOOL_CACHE}/${{ steps.pre.outputs.tool }}" ${{ steps.pre.outputs.locked }} ${{ steps.pre.outputs.features_flag }} ${{ steps.pre.outputs.no_default_features_flag }} ${{ steps.pre.outputs.all_features_flag }})
         if [[ -n "${{ steps.pre.outputs.git }}" ]]; then
           if [[ -n "${{ steps.pre.outputs.tag }}" ]]; then
             (

--- a/pre.sh
+++ b/pre.sh
@@ -327,10 +327,10 @@ bin_dir="${RUNNER_TOOL_CACHE}/${tool}/bin"
 printf '%s\n' "${bin_dir}" >>"${GITHUB_PATH}"
 
 if [[ -n "${git}" ]]; then
-  key="${tool}-git-${tag:+"tag-${tag}"}${rev:+"rev-${rev}"}-${host_arch}-${host_os}${locked_key}-features-${features:-default}${no_default_features:+-no-default-features}${all_features:+-all-features}"
+  key="${tool}-git-${tag:+"tag-${tag}"}${rev:+"rev-${rev}"}-${host_arch}-${host_os}${locked_key}-features-${features:-default}-no-default-features-${no_default_features}-all-features-${all_features}"
 else
   features="${features//,/-}" # Commas are not allowed in cache key names
-  key="${tool}-${version}-${host_arch}-${host_os}${locked_key}-features-${features:-default}${no_default_features:+-no-default-features}${all_features:+-all-features}"
+  key="${tool}-${version}-${host_arch}-${host_os}${locked_key}-features-${features:-default}-no-default-features-${no_default_features}-all-features-${all_features}"
 fi
 cat >>"${GITHUB_OUTPUT}" <<EOF
 tool=${tool}


### PR DESCRIPTION
This PR resolves #7 by implementing action inputs that allow customizing the `--features`, `--all-features`, and `--no-default-features` CLI flags that get passed to `cargo install`. If such inputs are not set, the specified tool is installed with its default feature set, as it was done before. I've tested the changes to work as expected on a production CI workflow.