### PR TITLE
Include user-agent header in requests to crates.io

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,7 @@ runs:
         INPUT_GIT: ${{ inputs.git }}
         INPUT_TAG: ${{ inputs.tag }}
         INPUT_REV: ${{ inputs.rev }}
+        ACTION_USER_AGENT: ${{ github.action_repository }} (${{ github.action_ref }})
     - name: Restore Cache
       id: cache
       uses: actions/cache@v4

--- a/pre.sh
+++ b/pre.sh
@@ -265,7 +265,7 @@ if [[ "${version}" == "latest" ]] || [[ -n "${fetch}" ]]; then
     *) bail "unsupported host OS '${host_os}'" ;;
   esac
 
-  crate_info=$(retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 "https://crates.io/api/v1/crates/${tool}")
+  crate_info=$(retry curl -v --user-agent "${ACTION_USER_AGENT}" --proto '=https' --tlsv1.2 -fsSL --retry 10 "https://crates.io/api/v1/crates/${tool}")
   case "${version}" in
     latest)
       version=$(jq -r '.crate.max_stable_version' <<<"${crate_info}")


### PR DESCRIPTION
This is currently "$REPO ($REF)" (ie, "User-Agent: ctz/cache-cargo-install-action (main)" and that should give crates.io sufficient information to complain to the right person if they don't like this traffic.

fixes #10 