### PR TITLE
fix: handle trailing whitespace in version parsing on Windows

### DIFF
--- a/pre.sh
+++ b/pre.sh
@@ -316,11 +316,12 @@ if [[ "${version}" == "latest" ]] || [[ -n "${fetch}" ]]; then
       versions=($(jq -r ".versions[] | select(.num | startswith(\"${version}.\")) | select(.yanked == false) | .num" <<<"${crate_info}"))
       full_version=''
       for v in ${versions[@]+"${versions[@]}"}; do
-        if [[ ! "${v}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z\.-]+)?$ ]]; then
-          continue
+        # On Windows, the version string can contain trailing whitespace (\r), so remove it.
+        v_cleaned="${v%%[[:space:]]}"
+        if [[ "${v_cleaned}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z\.-]+)?$ ]]; then
+          full_version="${v_cleaned}"
+          break
         fi
-        full_version="${v}"
-        break
       done
       if [[ -z "${full_version}" ]]; then
         bail "no stable version  found for ${tool} that match with '${version}.*'; if you want to install a pre-release version, please specify the full version"


### PR DESCRIPTION
## Problem

The `cache-cargo-install-action` fails on Windows when installing tools with partial version specifications (e.g., `tauri-cli@2`), while working correctly on other platforms.

### Configuration
```yaml
- name: Install Tauri CLI
  uses: taiki-e/cache-cargo-install-action@v2
  with:
    tool: tauri-cli@2
    locked: true
```

### Expected Behavior
The action should install the latest stable version of `tauri-cli` that matches major version 2 (currently `2.8.0`), equivalent to running:
```bash
cargo install tauri-cli --version '^2.0.0' --locked
```

### Actual Behavior
On Windows runners, the action fails with:
```
Error: no stable version found for tauri-cli that match with '2.*'; if you want to install a pre-release version, please specify the full version
```

<details>
  <summary>Workflow Failure Log</summary>
  
  ```
Run taiki-e/cache-cargo-install-action@v2
Run bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/pre.sh"
* Host crates.io:443 was resolved.
* IPv6: (none)
* IPv4: 108.138.64.108, 108.138.64.48, 108.138.64.68, 108.138.64.83
*   Trying 108.138.64.108:443...
* schannel: disabled automatic use of client certificate
* ALPN: curl offers http/1.1
* ALPN: server accepted http/1.1
* Connected to crates.io (108.138.64.108) port 443
* using HTTP/1.x
> GET /api/v1/crates/tauri-cli HTTP/1.1
> Host: crates.io
> User-Agent: taiki-e/cache-cargo-install-action (v2)
> Accept: */*

* Request completely sent off
* schannel: remote party requests renegotiation
* schannel: renegotiating SSL/TLS connection
* schannel: SSL/TLS connection renegotiated
< HTTP/1.1 200 OK

{ [14860 bytes data]
* Connection #0 to host crates.io left intact
Error: no stable version found for tauri-cli that match with '2.*'; if you want to install a pre-release version, please specify the full version
Error: Process completed with exit code 1.
  ```

	[Full Log](https://github.com/Xevion/byte-me/actions/runs/17108689008/job/48524243265)
</details>

## Root Cause

The version parsing logic in `pre.sh` doesn't handle trailing carriage return characters (`\r`) that can appear in JSON responses from the crates.io API on Windows systems. This causes the regex validation to fail when matching version strings.

## Solution

- Strip trailing whitespace using bash parameter expansion (`${v%%[[:space:]]}`) before regex validation

## Testing

No testing was added into this PR directly, but I tested it manually in my own project:

- [Error with the current v2 action](https://github.com/Xevion/byte-me/actions/runs/17108689008/job/48524243265)
- [Fixed with the new version](https://github.com/Xevion/byte-me/actions/runs/17108813972/job/48524676027)