### PR TITLE
fix: detect whether to use `jq -b` correctly on Windows

### DIFF
--- a/pre.sh
+++ b/pre.sh
@@ -316,12 +316,11 @@ if [[ "${version}" == "latest" ]] || [[ -n "${fetch}" ]]; then
       versions=($(jq -r ".versions[] | select(.num | startswith(\"${version}.\")) | select(.yanked == false) | .num" <<<"${crate_info}"))
       full_version=''
       for v in ${versions[@]+"${versions[@]}"}; do
-        # On Windows, the version string can contain trailing whitespace (\r), so remove it.
-        v_cleaned="${v%%[[:space:]]}"
-        if [[ "${v_cleaned}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z\.-]+)?$ ]]; then
-          full_version="${v_cleaned}"
-          break
+        if [[ ! "${v}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z\.-]+)?$ ]]; then
+          continue
         fi
+        full_version="${v}"
+        break
       done
       if [[ -z "${full_version}" ]]; then
         bail "no stable version  found for ${tool} that match with '${version}.*'; if you want to install a pre-release version, please specify the full version"

--- a/pre.sh
+++ b/pre.sh
@@ -274,10 +274,10 @@ if [[ "${version}" == "latest" ]] || [[ -n "${fetch}" ]]; then
         jq() { "${install_action_dir}/jq/bin/jq.exe" -b "$@"; }
       elif type -P jq >/dev/null; then
         # https://github.com/jqlang/jq/issues/1854
-        _tmp=$(jq -r .a <<<'{}')
-        if [[ "${_tmp}" != "null" ]]; then
-          _tmp=$(jq -b -r .a 2>/dev/null <<<'{}' || true)
-          if [[ "${_tmp}" == "null" ]]; then
+        _tmp=$(jq -r .a <<<'{}' | wc -c)
+        if [[ "${_tmp}" != 5 ]]; then
+          _tmp=$( (jq -b -r .a 2>/dev/null <<<'{}' || true) | wc -c)
+          if [[ "${_tmp}" == 5 ]]; then
             jq() { command jq -b "$@"; }
           else
             jq() { command jq "$@" | tr -d '\r'; }


### PR DESCRIPTION
This PR reverts #12 and applies a correct fix for https://github.com/taiki-e/cache-cargo-install-action/pull/12#issuecomment-3342493463.

The Bash bundled with Git for Windows removes trailing `\r` from value in variable assignment:
* https://github.com/msys2/MSYS2-packages/blob/8e4ba7001ea2e9f81550c01fa3149daef6502cf8/bash/0005-bash-4.3-msys2-fix-lineendings.patch#L17-L41

This patch results in the following different behavior which makes the comparison that tries to detect `null\r` always fail:

* Original Bash:
  ```console
  $ bash --version
  GNU bash, version 5.3.9(1)-release (x86_64-pc-linux-gnu)
  Copyright (C) 2025 Free Software Foundation, Inc.
  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
  
  This is free software; you are free to change and redistribute it.
  There is NO WARRANTY, to the extent permitted by law.
  
  $ foobar=$(printf '%s' $'foo\rbar')
  $ echo "${#foobar}"
  7
  ```
* MSYS2 Bash:
  ```console
  $ bash --version
  GNU bash, version 5.2.37(1)-release (x86_64-pc-msys)
  Copyright (C) 2022 Free Software Foundation, Inc.
  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
  
  This is free software; you are free to change and redistribute it.
  There is NO WARRANTY, to the extent permitted by law.

  $ foobar=$(printf '%s' $'foo\rbar')
  $ echo "${#foobar}"
  6
  ```

In order to correctly detect this case, I rewrote that part without variable assignment on MSYS2 Bash:

```console
$ jq --version
jq-1.8.1

$ jq -r .a <<<'{}' | wc -c
6

$ jq -b -r .a <<<'{}' | wc -c
5
```